### PR TITLE
head-corr

### DIFF
--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -142,14 +142,16 @@
       padding-top: 10px;
 
       @include tablet {
-        padding-top: 0;
+        padding-top: 0px;
+        padding-bottom: 5px;
       }
     }
     &--bottom {
       padding-bottom: 10px;
 
       @include tablet {
-        padding-bottom: 0;
+        padding-top: 5px;
+        padding-bottom: 0px;
       }
     }
   }


### PR DESCRIPTION
Поправила паддинги на номерах телефонов на таблетной версии (на десктопе были) для увеличения зоны кликабельности. Но поскольку там высота контента 50 px (без учета паддинга общего контейнера), то я извратилась и задала паддинги не внешние, а внутренние (вместо марджина, который разделял элементы) иначе не влезает по высоте. В общем, глянь, будет ли так ок.